### PR TITLE
correct package name should be google-genai instead of google-generativeai in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ python-dotenv
 selenium
 webdriver-manager
 requests
-google-generativeai
+google-genai
 Pillow==10.4.0
 pynput


### PR DESCRIPTION
If you install the requirements.txt, you will get error as following.  ai-captcha-bypass/main.py", line 16, in <module>
    from google import genai

so, correct package name should be google-genai instead of google-generativeai